### PR TITLE
Correct error regarding clustering/dispersion of L function

### DIFF
--- a/11-Point-Patterns.Rmd
+++ b/11-Point-Patterns.Rmd
@@ -547,12 +547,14 @@ L=\sqrt{\dfrac{K(d)}{\pi}}-d
 $$
 
 
-The $\hat{K}$ computed earlier is transformed to the following plot (note how the $K_{expecetd}$ red line is now perfectly horizontal)
+The $\hat{K}$ computed earlier is transformed to the following plot (note how the $K_{expecetd}$ red line is now perfectly horizontal):
 
 
-```{r f11-L, echo=FALSE, fig.cap="L-function (a simple transformation of the K-function). This graph makes it easier to compare K with K~expected~ at lower distance values. It appears that Walmart locations are more clustered than expected under CSR/IRP up to a distance of 12 km but more dispersed at distances greater than 12 km."}
+```{r f11-L, echo=FALSE, fig.cap="L-function (a simple transformation of the K-function)."}
 knitr::include_graphics("img/L_function.svg")
 ```
+
+This graph makes it easier to compare K with K~expected~ at lower distance values. Values greater than $0$ indicate clustering, while values less than $0$ indicate dispersion. It appears that Walmart locations are more dispersed than expected under CSR/IRP up to a distance of 12 km but more clustered at distances greater than 12 km.
 
 ### The Pair Correlation Function $g$
 

--- a/11-Point-Patterns.Rmd
+++ b/11-Point-Patterns.Rmd
@@ -547,14 +547,14 @@ L=\sqrt{\dfrac{K(d)}{\pi}}-d
 $$
 
 
-The $\hat{K}$ computed earlier is transformed to the following plot (note how the $K_{expecetd}$ red line is now perfectly horizontal):
+The $\hat{K}$ computed earlier is transformed to the following plot (note how the $K_{expected}$ red line is now perfectly horizontal):
 
 
 ```{r f11-L, echo=FALSE, fig.cap="L-function (a simple transformation of the K-function)."}
 knitr::include_graphics("img/L_function.svg")
 ```
 
-This graph makes it easier to compare K with K~expected~ at lower distance values. Values greater than $0$ indicate clustering, while values less than $0$ indicate dispersion. It appears that Walmart locations are more dispersed than expected under CSR/IRP up to a distance of 12 km but more clustered at distances greater than 12 km.
+This graph makes it easier to compare $K$ with $K_{expected}$ at lower distance values. Values greater than $0$ indicate clustering, while values less than $0$ indicate dispersion. It appears that Walmart locations are more dispersed than expected under CSR/IRP up to a distance of 12 km but more clustered at distances greater than 12 km.
 
 ### The Pair Correlation Function $g$
 


### PR DESCRIPTION
This is a top quality resource - I haven't found anything else quite like it. It presents the key concepts of GIS, GIScience and spatial analysis in easily-accessible language and presents the key details without "fluff". And it's available for free! Thank you, Manuel.

I just wanted to highlight and suggest a correction for an error in Chapter 11. The text said:

> It appears that Walmart locations are more **clustered** than expected under CSR/IRP up to a distance of 12 km but more **dispersed** at distances greater than 12 km.

However, this contradicts the preceding section, which says that Walmarts are more clustered than expected above 12 km.
